### PR TITLE
1. Fixed null reference when the file doesn't have any context.

### DIFF
--- a/Verification/Sdl.Verification.Sdk.IdenticalCheck.Extended/pluginpackage.manifest.xml
+++ b/Verification/Sdl.Verification.Sdk.IdenticalCheck.Extended/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>Identical Segment Verifier Extended</PlugInName>
-  <Version>1.0</Version>
+  <Version>1.1</Version>
   <Description>Verifies whether segments that are not supposed to be translated have been changed during translation/editing.</Description>
   <Author></Author>
   <RequiredProduct name="SDLTradosStudio" minversion="16.0" />

--- a/Verification/Sdl.Verification.Sdk.IdenticalCheck/IdenticalVerifierMain.cs
+++ b/Verification/Sdl.Verification.Sdk.IdenticalCheck/IdenticalVerifierMain.cs
@@ -4,6 +4,7 @@ using Sdl.FileTypeSupport.Framework.NativeApi;
 using Sdl.Verification.Api;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Sdl.Verification.Sdk.IdenticalCheck
 {
@@ -159,29 +160,31 @@ namespace Sdl.Verification.Sdk.IdenticalCheck
         #region "verify"
         private void CheckParagraphUnit(IParagraphUnit paragraphUnit)
         {
+	        if (paragraphUnit.Properties.Contexts is null) return;
             // loop through the whole paragraph unit
-            foreach (ISegmentPair segmentPair in paragraphUnit.SegmentPairs)
+            foreach (var segmentPair in paragraphUnit.SegmentPairs)
             {
-                // Determine if context information is available,
-                // and if the context equals the one specified in the user interface.
-                if (paragraphUnit.Properties.Contexts.Contexts.Count > 0 &&
-                    paragraphUnit.Properties.Contexts.Contexts[0].DisplayCode == VerificationSettings.CheckContext.Value)
-                {
+	            var paragraphContexts = paragraphUnit.Properties.Contexts.Contexts;
+	            if (paragraphContexts is null) return;
 
-                    // Check whether target differs from source.
-                    // If this is the case, then output a warning message
-                    if (segmentPair.Source.ToString() != segmentPair.Target.ToString())
-                    {
-                        MessageReporter.ReportMessage(this, PluginResources.Plugin_Name,
-                            ErrorLevel.Warning, PluginResources.Error_NotIdentical,
-                            new TextLocation(new Location(segmentPair.Target, true), 0),
-                            new TextLocation(new Location(segmentPair.Target, false), segmentPair.Target.ToString().Length - 1));
-                    }
+	            // Determine if context information is available,
+	            // and if the context contains the one specified in the user interface.
+                var paragraphContainsCheckContext =
+		            paragraphContexts.Any(c => c.DisplayCode !=null && c.DisplayCode.Contains(VerificationSettings.CheckContext.Value));
+
+                if (!paragraphContainsCheckContext) continue;
+
+                // Check whether target differs from source.
+                // If this is the case, then output a warning message
+                if (segmentPair.Source.ToString() != segmentPair.Target.ToString())
+                {
+	                MessageReporter.ReportMessage(this, PluginResources.Plugin_Name,
+		                ErrorLevel.Warning, PluginResources.Error_NotIdentical,
+		                new TextLocation(new Location(segmentPair.Target, true), 0),
+		                new TextLocation(new Location(segmentPair.Target, false), segmentPair.Target.ToString().Length - 1));
                 }
             }
         }
         #endregion
-
-
     }
 }

--- a/Verification/Sdl.Verification.Sdk.IdenticalCheck/pluginpackage.manifest.xml
+++ b/Verification/Sdl.Verification.Sdk.IdenticalCheck/pluginpackage.manifest.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>Identical Segment Verifier</PlugInName>
-  <Version>1.0</Version>
+  <Version>1.1</Version>
   <Description>Verifies whether segments that are not supposed to be translated have been changed during translation/editing.</Description>
   <Author></Author>
-  <RequiredProduct name="SDLTradosStudio" minversion="15.0" />
+  <RequiredProduct name="SDLTradosStudio" minversion="16.0" />
 </PluginPackage>


### PR DESCRIPTION
2. Check if the paragraph contains the searched context, we cannot take the first one from list becasue is not the one which is displayed in Studio, in case of sample project first one has DisplayCode null.
2. Changed minversion of Studio for IdenticalCheck plugin to prevent being installed on Studio 2019.